### PR TITLE
fix(seperator): default should be `-`

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -37,7 +37,7 @@ const operation: SandboxOperationConfig = {
     }
 
     const slugifyOptions: SlugifyOptions = {
-      separator: options.separator ?? "^",
+      separator: options.separator ?? "-",
       lowercase: options.lowercase ?? true,
       decamelize: options.decamelize ?? true,
     };


### PR DESCRIPTION
This PR fixes the seperator option to properly default to `-` as documented.