### PR TITLE
fix: typos for decamelize and object

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The separator to use between words. Defaults to `-`.
 
 Convert all string lowercase. Defaults to `true`.
 
-### Decamalize
+### Decamelize
 
 Convert camelcase to separate words (e.g. `loremIpsum` -> `lorem ipsum`). Defaults to `true`
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Replace specific characters or words with alternatives (.e.g `&` -> `and`). Addi
 
 ## Output
 
-An onject containing the slugified input.
+An object containing the slugified input.
 
 ```json
 { "slug": "[slug]" }

--- a/src/app.ts
+++ b/src/app.ts
@@ -51,8 +51,8 @@ export default defineOperationApp({
       },
     },
     {
-      field: "decamalize",
-      name: "Decamalize",
+      field: "decamelize",
+      name: "Decamelize",
       type: "boolean",
       meta: {
         width: "half",

--- a/src/app.ts
+++ b/src/app.ts
@@ -99,7 +99,6 @@ export default defineOperationApp({
             },
           ],
         },
-        note: "Add custom replacement options",
       },
     },
   ],


### PR DESCRIPTION
This PR fixes typos for decamelize and object throught the codebase